### PR TITLE
Provide support for logrotate facility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,7 @@ set (TEST_SRC_DIR \"${CMAKE_CURRENT_SOURCE_DIR}\")
 option (GLOG_NO_FILENAMES "Disable filenames in glog" 0)
 option (GLOG_NO_STACKTRACE "Disable stacktrace in glog" 0)
 option (GLOG_NO_BUFFER_SETTINGS "Disable buffer settings in glog" 0)
+option (GLOG_NO_TIME_PID_FILENAME "Disable appending time and PID to log filenames" 0)
 
 configure_file (src/config.h.cmake.in config.h)
 configure_file (src/glog/logging.h.in glog/logging.h @ONLY)

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -51,6 +51,7 @@
 #define GLOG_NO_FILENAMES @GLOG_NO_FILENAMES@
 #define GLOG_NO_STACKTRACE @GLOG_NO_STACKTRACE@
 #define GLOG_NO_BUFFER_SETTINGS @GLOG_NO_BUFFER_SETTINGS@
+#define GLOG_NO_TIME_PID_FILENAME @GLOG_NO_TIME_PID_FILENAME@
 
 // If this flag is true then don't store source filenames
 #if GLOG_NO_FILENAMES
@@ -1377,6 +1378,9 @@ GOOGLE_GLOG_DLL_DECL void FlushLogFiles(LogSeverity min_severity);
 // the specified severity level. Thread-hostile because it ignores
 // locking -- used for catastrophic failures.
 GOOGLE_GLOG_DLL_DECL void FlushLogFilesUnsafe(LogSeverity min_severity);
+
+// Closes the underlying file and opens it on the next log message.
+GOOGLE_GLOG_DLL_DECL void CloseLogDestination(LogSeverity severity);
 
 //
 // Set the destination to which a particular severity level of log


### PR DESCRIPTION
Logrotate support is made available by the new additions:

  * public API for closing the log destination file and
  * option for not including time and PID in log filename.

By not including time and PID in the filename, the logging will go to a
single file. If the file exists, it will append to the end. This file
should be set for rotation in logrotate configuration. Clients of glog
should call CloseLogDestination, when a logfile is rotated. The next log
message to be written, will recreate the original file.